### PR TITLE
Pin rabbitmq to 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq:management-alpine
+        image: rabbitmq:4.2-management-alpine
         options: >-
           --health-cmd "rabbitmq-diagnostics ping"
           --health-start-period 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - postgres:/var/lib/postgresql
 
   rabbitmq:
-    image: rabbitmq:management-alpine
+    image: rabbitmq:4.2-management-alpine
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       start_period: 30s


### PR DESCRIPTION
Recent Rabbitmq update breaks celery. 

> This only affects local developers and CI, since we don't use RabbitMQ in production with Heroku. - @brianhelba 