### PR TITLE
Update packages installed for simulations

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 # Install OpenMPI for simulations
 RUN sudo apt-get update && sudo apt-get install -y \
-    openmpi-bin \
+    libmpich-dev \
     libopenmpi-dev \
     && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I found that when running PHOLD I needed to add the `libmpich-dev`. Please check by spinning up a container without and running PHOLD. Then spin up a new container with this branch.
